### PR TITLE
Feat: display top interacted tags

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,8 @@ class HomeController < ApplicationController
                .order('count(posts.id) desc')
                .limit(5)
 
-    @top_interacted_tags = Tag.joins(posts: :tags)
+    @top_interacted_tags = Tag.joins(:posts)
+                              .where(posts: { status: :accepted })
                               .select('tags.*, SUM(posts.comments_count + posts.reactions_count) AS interactions')
                               .group('tags.id')
                               .order('interactions DESC')

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -20,5 +20,6 @@ class HomeController < ApplicationController
                               .group('tags.id')
                               .order('interactions DESC')
                               .limit(3)
+                              .preload(:posts)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
                .order('count(posts.id) desc')
                .limit(5)
 
-    @top_interacted_tags = Tag.joins(:posts)
+    @top_interacted_tags = Tag.joins(posts: :tags)
                               .select('tags.*, SUM(posts.comments_count + posts.reactions_count) AS interactions')
                               .group('tags.id')
                               .order('interactions DESC')

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,5 +13,11 @@ class HomeController < ApplicationController
                .group('tags.id')
                .order('count(posts.id) desc')
                .limit(5)
+
+    @top_interacted_tags = Tag.joins(:posts)
+                              .select('tags.*, SUM(posts.comments_count + posts.reactions_count) AS interactions')
+                              .group('tags.id')
+                              .order('interactions DESC')
+                              .limit(3)
   end
 end

--- a/app/javascript/stylesheets/home.scss
+++ b/app/javascript/stylesheets/home.scss
@@ -1,5 +1,5 @@
 @media (max-width: 768px) {
-  .home-page__sidebar {
+  .home-page__sidebar, .home-page__top-interacted-tags {
     display: none;
   }
 }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -94,8 +94,9 @@
               .px-4.py-2.border-bottom
                 .fs-5.fw-bold
                   = link_to tag_path(tag.name), class: "text-reset text-decoration-none" do
+                    | #
                     = tag.name
-              - tag.posts.accepted.limit(5).each do |post|
+              - tag.posts.accepted.order(created_at: :desc).limit(5).each do |post|
                 .px-4.py-3.border-bottom
                   .fs-6
                     = link_to post, class: "text-reset text-decoration-none" do

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -14,9 +14,10 @@
           | Search result for "
           = params[:search]
           | "
-    .container
-      .row.justify-content-center.gap-3
-        ul.col-xl-2.col-lg-3.col-md-3.col-sm-4.home-page__sidebar.p-0.pt-1
+    
+    .container.p-0
+      .row.justify-content-center
+        ul.col-xl-3.col-lg-3.col-md-3.col-sm-4.home-page__sidebar.pt-1
           li.home-page__sidebar__home
             = link_to root_path, class: "btn menu-link border-0 w-100 text-start mb-1" do
               = image_pack_tag "media/images/home-icon.svg", class: "pe-2" 
@@ -36,7 +37,7 @@
                   i class="fa-solid fa-chevron-down me-3"
                   | more
 
-        .col-lg-6.col-md-6.col-sm-12.col-12.home-page__main.p-0 data-controller="home" data-home-sort-value=params[:sort] data-home-filter-value=params[:filter] id="#home-page__main"
+        .col-lg-6.col-md-6.col-sm-12.col-12.home-page__main.p-sm-0.p-0 data-controller="home" data-home-sort-value=params[:sort] data-home-filter-value=params[:filter] id="#home-page__main"
           nav.navbar.navbar-expand.navbar-light.py-1 
             - if params[:search].present?
               = link_to "Lastest",
@@ -87,3 +88,21 @@
           .load-more__button.opacity-0.overflow-hidden
             == pagy_bootstrap_nav @pagy, pagy_id: "home-page__main__pagy-nav"
 
+        .col-lg-3.col-md-3.mt-2.home-page__top-interacted-tags
+          - @top_interacted_tags.each do |tag|
+            .mb-2.bg-white.border.rounded.shadow-sm
+              .px-4.py-2.border-bottom
+                .fs-5.fw-bold
+                  = link_to tag_path(tag.name), class: "text-reset text-decoration-none" do
+                    = tag.name
+              - tag.posts.accepted.each_with_index do |post, index|
+                - if index >= 5 
+                  - break
+
+                .px-4.py-3.border-bottom
+                  .fs-6
+                    = link_to post, class: "text-reset text-decoration-none" do
+                      = post.title
+                  small.text-secondary
+                    = post.comments.size
+                    |  comments

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -96,7 +96,7 @@
                   = link_to tag_path(tag.name), class: "text-reset text-decoration-none" do
                     | #
                     = tag.name
-              - tag.posts.accepted.order(created_at: :desc).limit(5).each do |post|
+              - tag.posts.sort_by { |post| post.created_at }.reverse.first(5).each do |post|
                 .px-4.py-3.border-bottom
                   .fs-6
                     = link_to post, class: "text-reset text-decoration-none" do

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -95,10 +95,7 @@
                 .fs-5.fw-bold
                   = link_to tag_path(tag.name), class: "text-reset text-decoration-none" do
                     = tag.name
-              - tag.posts.accepted.each_with_index do |post, index|
-                - if index >= 5 
-                  - break
-
+              - tag.posts.accepted.limit(5).each do |post|
                 .px-4.py-3.border-bottom
                   .fs-6
                     = link_to post, class: "text-reset text-decoration-none" do

--- a/app/views/shared/_post_tags_link.html.slim
+++ b/app/views/shared/_post_tags_link.html.slim
@@ -1,2 +1,4 @@
 - post.tags.each do |tag|
-  = link_to tag.name, tag_path(tag.name), class: "pe-3 text-secondary text-decoration-none"
+  = link_to tag_path(tag.name), class: "pe-3 text-secondary text-decoration-none" do 
+    | #
+    = tag.name


### PR DESCRIPTION
## This pull request
- Display top interacted tags with posts in right of home page

## Screenshot
![image](https://github.com/gareth-go/blog-website/assets/140365512/117af7e9-a18b-4f32-b6f7-6b113d1e1bca)

Checkpoint

- [ ] Checked the work against _all_ of the ticket requirements
- [ ] CHANGELOG updated
- [ ] Formatter has been run against all changed files
- [x] All changed files have been added correctly
- [ ] Appropriate unit tests and integration tests have been added
- [ ] All tests are passing
- [ ] Ad hoc testing has been done
- [ ] Affected docs have been updated
- [ ] All licenses have been checked and confirmed for commercial use

## Front End Specific

- [x] All styles have been applied and responsiveness tested
- [x] Changes have been checked on supported browsers
- [x] Changes have been checked on supported mobile devices
- [x] Assets are added and have been optimized
- [ ] End to end tests updated
- [ ] a11y concerns addressed
- [ ] Bundle builds and serves correctly

## Back End Specific

- [ ] Database migrations have been tested
- [ ] Necessary data patches have been prepared
- [ ] Infrastructure changes have been completed