### PR TITLE
Fix: n+1 query at home page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
     @posts = Post.where(status: Post.statuses[:accepted])
-                 .includes({ user: { avatar_attachment: :blob } }, :tags)
+                 .includes({ user: { avatar_attachment: :blob } }, :tags, :reactions)
     @posts = Posts::ListPostsService.call(@posts, params, current_user)
     # load cover image of first post
     @posts.first&.cover_image if params[:page].nil? || params[:page] == '1'

--- a/app/views/shared/_list_posts.html.slim
+++ b/app/views/shared/_list_posts.html.slim
@@ -22,19 +22,19 @@
         = link_to post, class: "text-decoration-none text-reset menu-link py-2 px-2 rounded" do
           = render "shared/reactions",
                    icon_src: "media/images/like-icon.svg",
-                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'like' }.size
+                   count: post.reactions.select(&:like?).size
           = render "shared/reactions",
                    icon_src: "media/images/unicorn-icon.svg",
-                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'unicorn' }.size
+                   count: post.reactions.select(&:unicorn?).size
           = render "shared/reactions",
                    icon_src: "media/images/exploding_head-icon.svg",
-                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'exploding_head' }.size
+                   count: post.reactions.select(&:exploding_head?).size
           = render "shared/reactions",
                    icon_src: "media/images/raised_hand-icon.svg",
-                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'raised_hand' }.size
+                   count: post.reactions.select(&:raised_hand?).size
           = render "shared/reactions",
                    icon_src: "media/images/fire-icon.svg",
-                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'fire' }.size
+                   count: post.reactions.select(&:fire?).size
           small.ms-1.align-bottom
             = post.reactions.size
             |  Reactions 

--- a/app/views/shared/_list_posts.html.slim
+++ b/app/views/shared/_list_posts.html.slim
@@ -1,4 +1,4 @@
-- posts.includes(:reactions).each_with_index do |post, index|
+- posts.each_with_index do |post, index|
   .mb-2.pb-2.bg-white.border.rounded.shadow-sm
     - if post.pending?
       .px-4.pt-2.text-warning

--- a/app/views/shared/_list_posts.html.slim
+++ b/app/views/shared/_list_posts.html.slim
@@ -1,4 +1,4 @@
-- posts.each_with_index do |post, index|
+- posts.includes(:reactions).each_with_index do |post, index|
   .mb-2.pb-2.bg-white.border.rounded.shadow-sm
     - if post.pending?
       .px-4.pt-2.text-warning
@@ -18,13 +18,23 @@
     .pb-2.px-4
       = render partial: "shared/post_tags_link", locals: { post: post }
     .pb-2.px-3
-      - if post.reactions.size > 0
+      - if post.reactions.present?
         = link_to post, class: "text-decoration-none text-reset menu-link py-2 px-2 rounded" do
-          = render "shared/reactions", icon_src: "media/images/like-icon.svg", count: post.reactions.like.size
-          = render "shared/reactions", icon_src: "media/images/unicorn-icon.svg", count: post.reactions.unicorn.size
-          = render "shared/reactions", icon_src: "media/images/exploding_head-icon.svg", count: post.reactions.exploding_head.size
-          = render "shared/reactions", icon_src: "media/images/raised_hand-icon.svg", count: post.reactions.raised_hand.size
-          = render "shared/reactions", icon_src: "media/images/fire-icon.svg", count: post.reactions.fire.size
+          = render "shared/reactions",
+                   icon_src: "media/images/like-icon.svg",
+                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'like' }.size
+          = render "shared/reactions",
+                   icon_src: "media/images/unicorn-icon.svg",
+                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'unicorn' }.size
+          = render "shared/reactions",
+                   icon_src: "media/images/exploding_head-icon.svg",
+                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'exploding_head' }.size
+          = render "shared/reactions",
+                   icon_src: "media/images/raised_hand-icon.svg",
+                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'raised_hand' }.size
+          = render "shared/reactions",
+                   icon_src: "media/images/fire-icon.svg",
+                   count: post.reactions.select{ |reaction| reaction.reaction_type == 'fire' }.size
           small.ms-1.align-bottom
             = post.reactions.size
             |  Reactions 


### PR DESCRIPTION
## This pull request
- Fix n+1 query at home page when counting reaction of each type

## Checkpoint

- [ ] Checked the work against _all_ of the ticket requirements
- [ ] CHANGELOG updated
- [ ] Formatter has been run against all changed files
- [x] All changed files have been added correctly
- [ ] Appropriate unit tests and integration tests have been added
- [ ] All tests are passing
- [ ] Ad hoc testing has been done
- [ ] Affected docs have been updated
- [ ] All licenses have been checked and confirmed for commercial use

## Front End Specific

- [ ] All styles have been applied and responsiveness tested
- [ ] Changes have been checked on supported browsers
- [ ] Changes have been checked on supported mobile devices
- [ ] Assets are added and have been optimized
- [ ] End to end tests updated
- [ ] a11y concerns addressed
- [ ] Bundle builds and serves correctly

## Back End Specific

- [ ] Database migrations have been tested
- [ ] Necessary data patches have been prepared
- [ ] Infrastructure changes have been completed