### PR TITLE
Fix: n+1 query when count reaction by type at show post page

### DIFF
--- a/app/views/posts/_reactions.html.slim
+++ b/app/views/posts/_reactions.html.slim
@@ -1,6 +1,6 @@
 .post__main__reactions.pb-3.px-5
-  = render "posts/reaction", icon_src: "media/images/like-icon.svg", count: post.reactions.like.size
-  = render "posts/reaction", icon_src: "media/images/unicorn-icon.svg", count: post.reactions.unicorn.size
-  = render "posts/reaction", icon_src: "media/images/exploding_head-icon.svg", count: post.reactions.exploding_head.size
-  = render "posts/reaction", icon_src: "media/images/raised_hand-icon.svg", count: post.reactions.raised_hand.size
-  = render "posts/reaction", icon_src: "media/images/fire-icon.svg", count: post.reactions.fire.size
+  = render "posts/reaction", icon_src: "media/images/like-icon.svg", count: post.reactions.select(&:like?).size
+  = render "posts/reaction", icon_src: "media/images/unicorn-icon.svg", count: post.reactions.select(&:unicorn?).size
+  = render "posts/reaction", icon_src: "media/images/exploding_head-icon.svg", count: post.reactions.select(&:exploding_head?).size
+  = render "posts/reaction", icon_src: "media/images/raised_hand-icon.svg", count: post.reactions.select(&:raised_hand?).size
+  = render "posts/reaction", icon_src: "media/images/fire-icon.svg", count: post.reactions.select(&:fire?).size

--- a/app/views/reactions/_post_reactions.html.slim
+++ b/app/views/reactions/_post_reactions.html.slim
@@ -9,8 +9,8 @@
       = reactions.size
   ul.post__option__reaction__menu.dropdown-menu.ms-2.px-3.rounded-5
     .d-flex.gap-1
-      = render partial: "reactions/reaction_type", locals: { type: "like", reaction: reaction, icon_src: "media/images/like-icon.svg", count: reactions.like.size, post: post }
-      = render partial: "reactions/reaction_type", locals: { type: "unicorn", reaction: reaction, icon_src: "media/images/unicorn-icon.svg", count: reactions.unicorn.size, post: post }
-      = render partial: "reactions/reaction_type", locals: { type: "exploding_head", reaction: reaction, icon_src: "media/images/exploding_head-icon.svg", count: reactions.exploding_head.size, post: post }
-      = render partial: "reactions/reaction_type", locals: { type: "raised_hand", reaction: reaction, icon_src: "media/images/raised_hand-icon.svg", count: reactions.raised_hand.size, post: post }
-      = render partial: "reactions/reaction_type", locals: { type: "fire", reaction: reaction, icon_src: "media/images/fire-icon.svg", count: reactions.fire.size, post: post }
+      = render partial: "reactions/reaction_type", locals: { type: "like", reaction: reaction, icon_src: "media/images/like-icon.svg", count: reactions.select(&:like?).size, post: post }
+      = render partial: "reactions/reaction_type", locals: { type: "unicorn", reaction: reaction, icon_src: "media/images/unicorn-icon.svg", count: reactions.select(&:unicorn?).size, post: post }
+      = render partial: "reactions/reaction_type", locals: { type: "exploding_head", reaction: reaction, icon_src: "media/images/exploding_head-icon.svg", count: reactions.select(&:exploding_head?).size, post: post }
+      = render partial: "reactions/reaction_type", locals: { type: "raised_hand", reaction: reaction, icon_src: "media/images/raised_hand-icon.svg", count: reactions.select(&:raised_hand?).size, post: post }
+      = render partial: "reactions/reaction_type", locals: { type: "fire", reaction: reaction, icon_src: "media/images/fire-icon.svg", count: reactions.select(&:fire?).size, post: post }


### PR DESCRIPTION
## This pull request
- Fix n+1 query at show post page when counting reaction of each type

## Checkpoint

- [ ] Checked the work against _all_ of the ticket requirements
- [ ] CHANGELOG updated
- [ ] Formatter has been run against all changed files
- [x] All changed files have been added correctly
- [ ] Appropriate unit tests and integration tests have been added
- [ ] All tests are passing
- [ ] Ad hoc testing has been done
- [ ] Affected docs have been updated
- [ ] All licenses have been checked and confirmed for commercial use

## Front End Specific

- [ ] All styles have been applied and responsiveness tested
- [ ] Changes have been checked on supported browsers
- [ ] Changes have been checked on supported mobile devices
- [ ] Assets are added and have been optimized
- [ ] End to end tests updated
- [ ] a11y concerns addressed
- [ ] Bundle builds and serves correctly

## Back End Specific

- [ ] Database migrations have been tested
- [ ] Necessary data patches have been prepared
- [ ] Infrastructure changes have been completed